### PR TITLE
chore: force Chalk colors in CI

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,3 @@
+# This forces chalk to use colors even in CI
+# See https://github.com/vitest-dev/vitest/issues/2732
+FORCE_COLOR=1

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,7 @@
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+	envPrefix: "FORCE_",
 	test: {
 		clearMocks: true,
 		coverage: {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to expect-no-axe-violations! 💖.
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #1 
- [x] That issue was marked as [accepting prs](https://github.com/JoshuaKGoldberg/expect-no-axe-violations/issues?q=is%3Aopen+is%3Aissue+label%3A%22accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/expect-no-axe-violations/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Passes a `FORCE_COLOR=1` flag so that `chalk` always assumes it should write colors. https://github.com/chalk/chalk#supportscolor.

Uses [`envPrefix`](https://vitejs.dev/config/shared-options.html#envprefix) so that Vite will pass the value along.